### PR TITLE
Statsd - mod to use nodejs cookbook rather and package in default recipe

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,8 +3,9 @@ maintainer_email "jon@blankpad.net"
 license          "Apache 2.0"
 description      "Installs/Configures statsd"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "0.0.1"
+version          "0.0.2"
 
 depends "build-essential"
 depends "git"
+depends "nodejs"
 supports "ubuntu"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@
 include_recipe "build-essential"
 include_recipe "git"
 
-package "nodejs"
+include_recipe "nodejs"
 
 statsd_version = node[:statsd][:sha]
 


### PR DESCRIPTION
these modifications will allow for full debian as well as ubuntu support although I suggest also adding a comment in the readme that for debian you must set nodejs cookbook to install from source (this can be done via the attributes though)
