### PR TITLE
Changes required to make cookbook work as expected

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,4 +10,5 @@ depends "build-essential"
 depends "git"
 depends "nodejs"
 
-supports "ubuntu redhat"
+supports "ubuntu"
+supports "redhat"


### PR DESCRIPTION
By default the cookbook would not build the statsd package and create some of the required directories. The changes below make it work beautifully on Chef 11.x and Ubuntu 12.04 LTS. I didn't see a test suite so I didn't write any tests.
